### PR TITLE
Refactor and update API surface including testing against Rust bindgen.

### DIFF
--- a/flatkrabsetw/dllmain.cpp
+++ b/flatkrabsetw/dllmain.cpp
@@ -8,8 +8,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
     UNREFERENCED_PARAMETER(ul_reason_for_call);
     UNREFERENCED_PARAMETER(lpReserved);
 
-    switch (ul_reason_for_call)
-    {
+    switch (ul_reason_for_call) {
     case DLL_PROCESS_ATTACH:
     case DLL_THREAD_ATTACH:
     case DLL_THREAD_DETACH:

--- a/flatkrabsetw/flatkrabsetw.cpp
+++ b/flatkrabsetw/flatkrabsetw.cpp
@@ -1,13 +1,33 @@
 
 #include "stdafx.h"
 #include <set>
+#include <string>
 #include "flatkrabsetw.h"
 #include <krabs.hpp>
 
 // Exported Functions
+FLATKRABSETW_API krabs_property_name* krabs_create_property_name(
+    krabs_status_ctx *status,
+    const wchar_t *property_name)
+{
+    ZeroMemory(status, sizeof krabs_status_ctx);
+    std::wstring *name = nullptr;
+
+    try {
+        name = new std::wstring(property_name);
+    }
+    catch (const std::exception& ex) {
+        strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
+        status->status = krabs_error_unknown_error;
+    }
+
+    return (krabs_property_name*)name;
+}
+
+
 FLATKRABSETW_API krabs_user_trace* krabs_create_user_trace(
     krabs_status_ctx *status,
-    const wchar_t *name)
+    const wchar_t *const name)
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
     krabs::user_trace *trace = nullptr;
@@ -25,7 +45,7 @@ FLATKRABSETW_API krabs_user_trace* krabs_create_user_trace(
 
 FLATKRABSETW_API krabs_user_provider* krabs_create_user_provider(
     krabs_status_ctx *status,
-    const wchar_t *provider_name,
+    const wchar_t *const provider_name,
     ULONGLONG any_flags,
     ULONGLONG all_flags)
 {
@@ -48,8 +68,8 @@ FLATKRABSETW_API krabs_user_provider* krabs_create_user_provider(
 
 FLATKRABSETW_API void krabs_enable_user_provider(
     krabs_status_ctx *status,
-    krabs_user_trace *trace,
-    krabs_user_provider *provider)
+    krabs_user_trace *const trace,
+    krabs_user_provider *const provider)
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
     try {
@@ -65,7 +85,7 @@ FLATKRABSETW_API void krabs_enable_user_provider(
 
 FLATKRABSETW_API krabs_filter* krabs_create_filter_for_event_ids(
     krabs_status_ctx *status,
-    const USHORT *event_ids,
+    const USHORT *const event_ids,
     size_t event_ids_count)
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
@@ -101,7 +121,7 @@ FLATKRABSETW_API krabs_filter* krabs_create_filter_for_event_ids(
 
 FLATKRABSETW_API void krabs_add_event_callback_to_user_provider(
     krabs_status_ctx *status,
-    krabs_user_provider *provider,
+    krabs_user_provider *const provider,
     krabs_callback callback)
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
@@ -119,7 +139,7 @@ FLATKRABSETW_API void krabs_add_event_callback_to_user_provider(
 
 FLATKRABSETW_API void krabs_add_callback_to_event_filter(
     krabs_status_ctx *status,
-    krabs_filter *filter,
+    krabs_filter *const filter,
     krabs_callback callback)
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
@@ -136,8 +156,8 @@ FLATKRABSETW_API void krabs_add_callback_to_event_filter(
 
 FLATKRABSETW_API void krabs_add_event_filter_to_user_provider(
     krabs_status_ctx *status,
-    krabs_user_provider *provider,
-    krabs_filter *filter)
+    krabs_user_provider *const provider,
+    krabs_filter *const filter)
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
 
@@ -155,7 +175,7 @@ FLATKRABSETW_API void krabs_add_event_filter_to_user_provider(
 
 FLATKRABSETW_API void krabs_start_trace(
     krabs_status_ctx *status,
-    krabs_user_trace *trace)
+    krabs_user_trace *const trace)
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
 
@@ -163,8 +183,7 @@ FLATKRABSETW_API void krabs_start_trace(
         krabs::user_trace *unwrapped_trace = (krabs::user_trace*)trace;
         unwrapped_trace->start();
     }
-    catch (const std::exception& ex)
-    {
+    catch (const std::exception& ex) {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
         status->status = krabs_error_unknown_error;
     }
@@ -172,7 +191,7 @@ FLATKRABSETW_API void krabs_start_trace(
 
 FLATKRABSETW_API void krabs_stop_trace(
     krabs_status_ctx *status,
-    krabs_user_trace *trace)
+    krabs_user_trace *const trace)
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
 
@@ -180,12 +199,126 @@ FLATKRABSETW_API void krabs_stop_trace(
         krabs::user_trace* unwrapped_trace = (krabs::user_trace*)trace;
         unwrapped_trace->stop();
     }
-    catch (const std::exception& ex)
-    {
+    catch (const std::exception& ex) {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
         status->status = krabs_error_unknown_error;
     }
 }
+
+FLATKRABSETW_API krabs_event_schema* krabs_get_event_schema(
+    krabs_status_ctx *status,
+    const EVENT_RECORD& rec)
+{
+    ZeroMemory(status, sizeof krabs_status_ctx);
+
+    krabs::schema *schema = nullptr;
+
+    try {
+        schema = new krabs::schema(rec);
+    }
+    catch (const std::exception& ex) {
+        strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
+        status->status = krabs_error_unknown_error;
+    }
+
+    return (krabs_event_schema*)schema;
+}
+
+FLATKRABSETW_API krabs_event_parser* krabs_get_event_parser(
+    krabs_status_ctx *status,
+    krabs_event_schema *const schema)
+{
+    ZeroMemory(status, sizeof krabs_status_ctx);
+
+    krabs::parser *parser = nullptr;
+
+    try {
+        krabs::schema *unwrapped_schema = (krabs::schema*)schema;
+        parser = new krabs::parser(*unwrapped_schema);
+    }
+    catch (const std::exception& ex) {
+        strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
+        status->status = krabs_error_unknown_error;
+    }
+
+    return (krabs_event_parser*)parser;
+}
+
+/// Schema fetching functions
+#pragma region Schema
+std::wstring skinny_to_wide(const std::string &str) {
+    if (str.empty()) {
+        return std::wstring();
+    }
+
+    size_t chars_needed = ::MultiByteToWideChar(CP_UTF8, 0,
+        str.data(), (int)str.size(), NULL, 0);
+    if (chars_needed == 0) {
+        throw std::runtime_error("Failed converting UTF-8 string to UTF-16");
+    }
+
+    std::vector<wchar_t> buffer(chars_needed);
+    int chars_converted = ::MultiByteToWideChar(CP_UTF8, 0,
+        str.data(), (int)str.size(), &buffer[0], (int)buffer.size());
+    if (chars_converted == 0) {
+        throw std::runtime_error("Failed converting UTF-8 string to UTF-16");
+    }
+
+    return std::wstring(&buffer[0], chars_converted);
+}
+
+FLATKRABSETW_API wchar_t* krabs_get_string_property_from_parser(
+    krabs_status_ctx *status,
+    krabs_event_parser *const parser,
+    krabs_property_name *const property_name,
+    krabs_string_type string_type)
+{
+    ZeroMemory(status, sizeof krabs_status_ctx);
+
+    wchar_t *ret = nullptr;
+
+    try {
+        krabs::parser *unwrapped_parser = (krabs::parser*)parser;
+        const std::wstring* unwrapped_property_name = (const std::wstring*)property_name;
+
+        switch (string_type) {
+        case krabs_string_type::std_string:
+        {
+            std::string skinny = unwrapped_parser->parse<std::string>(*unwrapped_property_name);
+            std::wstring wide = skinny_to_wide(skinny);
+            size_t alloc_size = wide.length() + 1;
+            ret = new wchar_t[alloc_size];
+            wcscpy_s(ret, alloc_size, wide.c_str());
+            break;
+        }
+        case krabs_string_type::std_wstring:
+        {
+            std::wstring wide = unwrapped_parser->parse<std::wstring>(*unwrapped_property_name);
+            size_t alloc_size = wide.length() + 1;
+            ret = new wchar_t[alloc_size];
+            wcscpy_s(ret, alloc_size, wide.c_str());
+            break;
+        }
+        case krabs_string_type::counted_wide_string:
+        {
+            auto parsed = unwrapped_parser->parse<const krabs::counted_string*>(*unwrapped_property_name);
+            auto alloc_size = parsed->length() + 1;
+            ret = new wchar_t[alloc_size];
+            wcsncpy_s(ret, alloc_size, parsed->string(), alloc_size - 1);
+            break;
+        }
+        }
+    }
+    catch (const std::exception& ex) {
+        strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
+        status->status = krabs_error_unknown_error;
+    }
+
+    return ret;
+}
+#pragma endregion
+
+#pragma region DestroyFunctions
 
 FLATKRABSETW_API void krabs_destroy_user_provider(
     krabs_user_provider *provider)
@@ -210,3 +343,29 @@ FLATKRABSETW_API void krabs_destroy_event_filter(
         delete ((krabs::event_filter*)filter);
     }
 }
+
+FLATKRABSETW_API void krabs_destroy_event_schema(
+    krabs_event_schema *schema)
+{
+    if (schema) {
+        delete ((krabs::schema*)schema);
+    }
+}
+
+FLATKRABSETW_API void krabs_destroy_event_parser(
+    krabs_event_parser *parser)
+{
+    if (parser) {
+        delete ((krabs::parser*)parser);
+    }
+}
+
+FLATKRABSETW_API void krabs_destroy_property_name(
+    krabs_property_name *property_name)
+{
+    if (property_name) {
+        delete ((std::wstring*)property_name);
+    }
+}
+
+#pragma endregion

--- a/flatkrabsetw/flatkrabsetw.cpp
+++ b/flatkrabsetw/flatkrabsetw.cpp
@@ -5,6 +5,12 @@
 #include "flatkrabsetw.h"
 #include <krabs.hpp>
 
+void throw_if_bad_alloc(void* ptr) {
+    if (ptr == nullptr) {
+        throw std::bad_alloc();
+    }
+}
+
 // Exported Functions
 FLATKRABSETW_API krabs_property_name* krabs_create_property_name(
     krabs_status_ctx *status,
@@ -15,6 +21,7 @@ FLATKRABSETW_API krabs_property_name* krabs_create_property_name(
 
     try {
         name = new std::wstring(property_name);
+        throw_if_bad_alloc(name);
     }
     catch (const std::exception& ex) {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
@@ -23,7 +30,6 @@ FLATKRABSETW_API krabs_property_name* krabs_create_property_name(
 
     return (krabs_property_name*)name;
 }
-
 
 FLATKRABSETW_API krabs_user_trace* krabs_create_user_trace(
     krabs_status_ctx *status,
@@ -34,6 +40,7 @@ FLATKRABSETW_API krabs_user_trace* krabs_create_user_trace(
 
     try {
         trace = new krabs::user_trace(name);
+        throw_if_bad_alloc(trace);
     }
     catch (const std::exception& ex) {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
@@ -54,6 +61,7 @@ FLATKRABSETW_API krabs_user_provider* krabs_create_user_provider(
 
     try {
         provider = new krabs::provider<>(provider_name);
+        throw_if_bad_alloc(provider);
         provider->any(any_flags);
         provider->all(all_flags);
     }
@@ -110,6 +118,7 @@ FLATKRABSETW_API krabs_filter* krabs_create_filter_for_event_ids(
         };
 
         filter = new krabs::event_filter(predicate);
+        throw_if_bad_alloc(filter);
     }
     catch (const std::exception& ex) {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
@@ -215,6 +224,7 @@ FLATKRABSETW_API krabs_event_schema* krabs_get_event_schema(
 
     try {
         schema = new krabs::schema(rec);
+        throw_if_bad_alloc(schema);
     }
     catch (const std::exception& ex) {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
@@ -235,6 +245,7 @@ FLATKRABSETW_API krabs_event_parser* krabs_get_event_parser(
     try {
         krabs::schema *unwrapped_schema = (krabs::schema*)schema;
         parser = new krabs::parser(*unwrapped_schema);
+        throw_if_bad_alloc(parser);
     }
     catch (const std::exception& ex) {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
@@ -288,6 +299,7 @@ FLATKRABSETW_API wchar_t* krabs_get_string_property_from_parser(
             std::wstring wide = skinny_to_wide(skinny);
             size_t alloc_size = wide.length() + 1;
             ret = new wchar_t[alloc_size];
+            throw_if_bad_alloc(ret);
             wcscpy_s(ret, alloc_size, wide.c_str());
             break;
         }
@@ -296,6 +308,7 @@ FLATKRABSETW_API wchar_t* krabs_get_string_property_from_parser(
             std::wstring wide = unwrapped_parser->parse<std::wstring>(*unwrapped_property_name);
             size_t alloc_size = wide.length() + 1;
             ret = new wchar_t[alloc_size];
+            throw_if_bad_alloc(ret);
             wcscpy_s(ret, alloc_size, wide.c_str());
             break;
         }
@@ -304,6 +317,7 @@ FLATKRABSETW_API wchar_t* krabs_get_string_property_from_parser(
             auto parsed = unwrapped_parser->parse<const krabs::counted_string*>(*unwrapped_property_name);
             auto alloc_size = parsed->length() + 1;
             ret = new wchar_t[alloc_size];
+            throw_if_bad_alloc(ret);
             wcsncpy_s(ret, alloc_size, parsed->string(), alloc_size - 1);
             break;
         }

--- a/flatkrabsetw/flatkrabsetw.cpp
+++ b/flatkrabsetw/flatkrabsetw.cpp
@@ -1,48 +1,43 @@
 
 #include "stdafx.h"
+#include <set>
 #include "flatkrabsetw.h"
 #include <krabs.hpp>
 
 // Exported Functions
-FLATKRABSETW_API krabs_user_trace *krabs_create_user_trace(
+FLATKRABSETW_API krabs_user_trace* krabs_create_user_trace(
     krabs_status_ctx *status,
     const wchar_t *name)
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
-    krabs::user_trace *trace;
+    krabs::user_trace *trace = nullptr;
 
-    try
-    {
+    try {
         trace = new krabs::user_trace(name);
     }
-    catch (std::exception& ex)
-    {
+    catch (const std::exception& ex) {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
         status->status = krabs_error_unknown_error;
-        return nullptr;
     }
 
     return (krabs_user_trace*)trace;
 }
 
-FLATKRABSETW_API krabs_user_provider *krabs_create_user_provider(
+FLATKRABSETW_API krabs_user_provider* krabs_create_user_provider(
     krabs_status_ctx *status,
-    krabs_user_trace *trace,
     const wchar_t *provider_name,
     ULONGLONG any_flags,
     ULONGLONG all_flags)
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
-    krabs::provider<> *provider;
+    krabs::provider<> *provider = nullptr;
 
-    try
-    {
+    try {
         provider = new krabs::provider<>(provider_name);
         provider->any(any_flags);
         provider->all(all_flags);
     }
-    catch (std::exception& ex)
-    {
+    catch (const std::exception& ex) {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
         status->status = krabs_error_unknown_error;
         return nullptr;
@@ -57,52 +52,102 @@ FLATKRABSETW_API void krabs_enable_user_provider(
     krabs_user_provider *provider)
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
-    try
-    {
+    try {
         krabs::user_trace* unwrapped_trace = (krabs::user_trace*)trace;
         krabs::provider<>* unwrapped_provider = (krabs::provider<>*)provider;
         unwrapped_trace->enable(*unwrapped_provider);
     }
-    catch (std::exception& ex)
-    {
+    catch (const std::exception& ex) {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
         status->status = krabs_error_unknown_error;
     }
 }
 
-FLATKRABSETW_API krabs_filter *krabs_create_filter(krabs_status_ctx *status)
+FLATKRABSETW_API krabs_filter* krabs_create_filter_for_event_ids(
+    krabs_status_ctx *status,
+    const USHORT *event_ids,
+    size_t event_ids_count)
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
-    krabs::event_filter* filter;
+    krabs::event_filter *filter = nullptr;
 
-    try
-    {
-        filter = new krabs::event_filter(krabs::predicates::any_event);
+    try {
+        if (event_ids == nullptr) {
+            throw std::invalid_argument("event_ids parameter is null");
+        }
+
+        if (event_ids_count <= 0) {
+            throw std::invalid_argument("event_ids_count parameter is less than or equal to 0");
+        }
+
+        std::set<uint16_t> event_ids_to_filter;
+        for (auto ii = 0; ii < event_ids_count; ++ii) {
+            event_ids_to_filter.insert(event_ids[ii]);
+        }
+
+        auto predicate = [event_ids_to_filter](const EVENT_RECORD &record) -> bool {
+            return event_ids_to_filter.find(record.EventHeader.EventDescriptor.Id) != event_ids_to_filter.end();
+        };
+
+        filter = new krabs::event_filter(predicate);
     }
-    catch (std::exception& ex)
-    {
+    catch (const std::exception& ex) {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
         status->status = krabs_error_unknown_error;
-        return nullptr;
     }
 
     return (krabs_filter*)filter;
 }
 
-FLATKRABSETW_API void krabs_add_event_callback_to_provider(
+FLATKRABSETW_API void krabs_add_event_callback_to_user_provider(
     krabs_status_ctx *status,
     krabs_user_provider *provider,
     krabs_callback callback)
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
 
-    try
-    {
+    try {
         krabs::provider<> *unwrapped_provider = (krabs::provider<>*)provider;
         unwrapped_provider->add_on_event_callback(callback);
     }
-    catch (std::exception& ex)
+    catch (const std::exception& ex)
     {
+        strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
+        status->status = krabs_error_unknown_error;
+    }
+}
+
+FLATKRABSETW_API void krabs_add_callback_to_event_filter(
+    krabs_status_ctx *status,
+    krabs_filter *filter,
+    krabs_callback callback)
+{
+    ZeroMemory(status, sizeof krabs_status_ctx);
+
+    try {
+        krabs::event_filter *unwrapped_filter = (krabs::event_filter*)filter;
+        unwrapped_filter->add_on_event_callback(callback);
+    }
+    catch (const std::exception& ex) {
+        strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
+        status->status = krabs_error_unknown_error;
+    }
+}
+
+FLATKRABSETW_API void krabs_add_event_filter_to_user_provider(
+    krabs_status_ctx *status,
+    krabs_user_provider *provider,
+    krabs_filter *filter)
+{
+    ZeroMemory(status, sizeof krabs_status_ctx);
+
+    try {
+        krabs::event_filter *unwrapped_filter = (krabs::event_filter*)filter;
+        krabs::provider<> *unwrapped_provider = (krabs::provider<>*)provider;
+
+        unwrapped_provider->add_filter(*unwrapped_filter);
+    }
+    catch (const std::exception& ex) {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
         status->status = krabs_error_unknown_error;
     }
@@ -114,12 +159,11 @@ FLATKRABSETW_API void krabs_start_trace(
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
 
-    try
-    {
-        krabs::user_trace* unwrapped_trace = (krabs::user_trace*)trace;
+    try {
+        krabs::user_trace *unwrapped_trace = (krabs::user_trace*)trace;
         unwrapped_trace->start();
     }
-    catch (std::exception& ex)
+    catch (const std::exception& ex)
     {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
         status->status = krabs_error_unknown_error;
@@ -132,38 +176,37 @@ FLATKRABSETW_API void krabs_stop_trace(
 {
     ZeroMemory(status, sizeof krabs_status_ctx);
 
-    try
-    {
+    try {
         krabs::user_trace* unwrapped_trace = (krabs::user_trace*)trace;
         unwrapped_trace->stop();
     }
-    catch (std::exception& ex)
+    catch (const std::exception& ex)
     {
         strcpy_s(status->msg, ARRAYSIZE(status->msg), ex.what());
         status->status = krabs_error_unknown_error;
     }
 }
 
-FLATKRABSETW_API void krabs_destroy_user_provider(krabs_user_provider *provider)
+FLATKRABSETW_API void krabs_destroy_user_provider(
+    krabs_user_provider *provider)
 {
-    if (provider)
-    {
+    if (provider) {
         delete ((krabs::provider<>*)provider);
     }
 }
 
-FLATKRABSETW_API void krabs_destroy_user_trace(krabs_user_trace *trace)
+FLATKRABSETW_API void krabs_destroy_user_trace(
+    krabs_user_trace *trace)
 {
-    if (trace)
-    {
+    if (trace) {
         delete ((krabs::user_trace*)trace);
     }
 }
 
-FLATKRABSETW_API void krabs_destroy_krabs_filter(krabs_filter *filter)
+FLATKRABSETW_API void krabs_destroy_event_filter(
+    krabs_filter *filter)
 {
-    if (filter)
-    {
+    if (filter) {
         delete ((krabs::event_filter*)filter);
     }
 }

--- a/flatkrabsetw/flatkrabsetw.h
+++ b/flatkrabsetw/flatkrabsetw.h
@@ -40,6 +40,14 @@ extern "C" {
     } krabs_string_type;
 
     typedef struct {
+        union {
+            DWORD v4;
+            BYTE v6[16];
+        };
+        bool is_ipv6;
+    } krabs_ip_address;
+
+    typedef struct {
         krabs_status_t status;
         char msg[256];
     } krabs_status_ctx;
@@ -124,6 +132,24 @@ extern "C" {
         krabs_event_parser *const parser,
         krabs_property_name *const property_name,
         krabs_string_type string_type
+    );
+
+    FLATKRABSETW_API uint32_t krabs_get_u32_property_from_parser(
+        krabs_status_ctx *status,
+        krabs_event_parser *const parser,
+        krabs_property_name *const property_name
+    );
+
+    FLATKRABSETW_API uint16_t krabs_get_u16_property_from_parser(
+        krabs_status_ctx *status,
+        krabs_event_parser *const parser,
+        krabs_property_name *const property_name
+    );
+
+    FLATKRABSETW_API krabs_ip_address* krabs_get_ip_addr_property_from_parser(
+        krabs_status_ctx *status,
+        krabs_event_parser *const parser,
+        krabs_property_name *const property_name
     );
 
     FLATKRABSETW_API void krabs_destroy_user_provider(

--- a/flatkrabsetw/flatkrabsetw.h
+++ b/flatkrabsetw/flatkrabsetw.h
@@ -21,8 +21,7 @@ typedef void(*krabs_callback)(const EVENT_RECORD &);
 extern "C" {
 #endif
 
-    typedef enum
-    {
+    typedef enum {
         krabs_success = 0,
         krabs_error_unknown_error = 1,
         krabs_error_invalid_parameter = 2,
@@ -34,56 +33,73 @@ extern "C" {
         krabs_error_trace_already_registered = 8,
     } krabs_status_t;
 
-    typedef struct
-    {
+    typedef struct {
         krabs_status_t status;
         char msg[256];
     } krabs_status_ctx;
 
     DECLARE_HANDLE(krabs_filter);
-
     DECLARE_HANDLE(krabs_user_trace);
     DECLARE_HANDLE(krabs_user_provider);
 
     // Exported Functions
-    FLATKRABSETW_API krabs_user_trace *krabs_create_user_trace(
+    FLATKRABSETW_API krabs_user_trace* krabs_create_user_trace(
         krabs_status_ctx *status,
-        const wchar_t *name);
+        const wchar_t *name
+    );
 
-    FLATKRABSETW_API krabs_user_provider *krabs_create_user_provider(
+    FLATKRABSETW_API krabs_user_provider* krabs_create_user_provider(
         krabs_status_ctx *status,
-        krabs_user_trace *trace,
         const wchar_t *provider_name,
         ULONGLONG any_flags,
-        ULONGLONG all_flags);
+        ULONGLONG all_flags
+    );
 
     FLATKRABSETW_API void krabs_enable_user_provider(
         krabs_status_ctx *status,
         krabs_user_trace *trace,
-        krabs_user_provider *provider);
-
-    FLATKRABSETW_API krabs_filter *krabs_create_filter(
-        krabs_status_ctx *status
+        krabs_user_provider *provider
     );
 
-    FLATKRABSETW_API void krabs_add_event_callback_to_provider(
+    FLATKRABSETW_API krabs_filter* krabs_create_filter_for_event_ids(
         krabs_status_ctx *status,
-        krabs_user_provider* provider,
-        krabs_callback callback);
+        const USHORT *event_ids,
+        size_t event_ids_count
+    );
+
+    FLATKRABSETW_API void krabs_add_event_callback_to_user_provider(
+        krabs_status_ctx *status,
+        krabs_user_provider *provider,
+        krabs_callback callback
+    );
+
+    FLATKRABSETW_API void krabs_add_callback_to_event_filter(
+        krabs_status_ctx *status,
+        krabs_filter *filter,
+        krabs_callback callback
+    );
+
+    FLATKRABSETW_API void krabs_add_event_filter_to_user_provider(
+        krabs_status_ctx *status,
+        krabs_user_provider *provider,
+        krabs_filter *filter
+    );
 
     FLATKRABSETW_API void krabs_start_trace(
         krabs_status_ctx *status,
-        krabs_user_trace *trace);
+        krabs_user_trace *trace
+    );
 
     FLATKRABSETW_API void krabs_stop_trace(
         krabs_status_ctx *status,
-        krabs_user_trace *trace);
+        krabs_user_trace *trace
+    );
 
     FLATKRABSETW_API void krabs_destroy_user_provider(krabs_user_provider *provider);
 
     FLATKRABSETW_API void krabs_destroy_user_trace(krabs_user_trace *trace);
 
-    FLATKRABSETW_API void krabs_destroy_krabs_filter(krabs_filter *filter);
+    FLATKRABSETW_API void krabs_destroy_event_filter(krabs_filter *filter);
 
 #ifdef __cplusplus
 }

--- a/flatkrabsetw/flatkrabsetw.h
+++ b/flatkrabsetw/flatkrabsetw.h
@@ -15,7 +15,7 @@
 #define FLATKRABSETW_API __declspec(dllimport)
 #endif
 
-typedef void(*krabs_callback)(const EVENT_RECORD &);
+typedef void(*krabs_callback)(const EVENT_RECORD *);
 
 #ifdef __cplusplus
 extern "C" {
@@ -111,7 +111,7 @@ extern "C" {
 
     FLATKRABSETW_API krabs_event_schema* krabs_get_event_schema(
         krabs_status_ctx *status,
-        const EVENT_RECORD& rec
+        const EVENT_RECORD *rec
     );
 
     FLATKRABSETW_API krabs_event_parser* krabs_get_event_parser(

--- a/flatkrabsetw/flatkrabsetw.h
+++ b/flatkrabsetw/flatkrabsetw.h
@@ -33,6 +33,12 @@ extern "C" {
         krabs_error_trace_already_registered = 8,
     } krabs_status_t;
 
+    typedef enum {
+        std_string,
+        std_wstring,
+        counted_wide_string,
+    } krabs_string_type;
+
     typedef struct {
         krabs_status_t status;
         char msg[256];
@@ -41,8 +47,16 @@ extern "C" {
     DECLARE_HANDLE(krabs_filter);
     DECLARE_HANDLE(krabs_user_trace);
     DECLARE_HANDLE(krabs_user_provider);
+    DECLARE_HANDLE(krabs_event_schema);
+    DECLARE_HANDLE(krabs_event_parser);
+    DECLARE_HANDLE(krabs_property_name);
 
     // Exported Functions
+    FLATKRABSETW_API krabs_property_name* krabs_create_property_name(
+        krabs_status_ctx *status,
+        const wchar_t *name
+    );
+
     FLATKRABSETW_API krabs_user_trace* krabs_create_user_trace(
         krabs_status_ctx *status,
         const wchar_t *name
@@ -50,56 +64,91 @@ extern "C" {
 
     FLATKRABSETW_API krabs_user_provider* krabs_create_user_provider(
         krabs_status_ctx *status,
-        const wchar_t *provider_name,
+        const wchar_t *const provider_name,
         ULONGLONG any_flags,
         ULONGLONG all_flags
     );
 
     FLATKRABSETW_API void krabs_enable_user_provider(
-        krabs_status_ctx *status,
-        krabs_user_trace *trace,
+        krabs_status_ctx * status,
+        krabs_user_trace *const trace,
         krabs_user_provider *provider
     );
 
     FLATKRABSETW_API krabs_filter* krabs_create_filter_for_event_ids(
         krabs_status_ctx *status,
-        const USHORT *event_ids,
+        const USHORT *const event_ids,
         size_t event_ids_count
     );
 
     FLATKRABSETW_API void krabs_add_event_callback_to_user_provider(
         krabs_status_ctx *status,
-        krabs_user_provider *provider,
+        krabs_user_provider *const provider,
         krabs_callback callback
     );
 
     FLATKRABSETW_API void krabs_add_callback_to_event_filter(
         krabs_status_ctx *status,
-        krabs_filter *filter,
+        krabs_filter *const filter,
         krabs_callback callback
     );
 
     FLATKRABSETW_API void krabs_add_event_filter_to_user_provider(
         krabs_status_ctx *status,
-        krabs_user_provider *provider,
-        krabs_filter *filter
+        krabs_user_provider *const provider,
+        krabs_filter *const filter
     );
 
     FLATKRABSETW_API void krabs_start_trace(
         krabs_status_ctx *status,
-        krabs_user_trace *trace
+        krabs_user_trace *const trace
     );
 
     FLATKRABSETW_API void krabs_stop_trace(
         krabs_status_ctx *status,
+        krabs_user_trace *const trace
+    );
+
+    FLATKRABSETW_API krabs_event_schema* krabs_get_event_schema(
+        krabs_status_ctx *status,
+        const EVENT_RECORD& rec
+    );
+
+    FLATKRABSETW_API krabs_event_parser* krabs_get_event_parser(
+        krabs_status_ctx *status,
+        krabs_event_schema *const schema
+    );
+
+    FLATKRABSETW_API wchar_t* krabs_get_string_property_from_parser(
+        krabs_status_ctx *status,
+        krabs_event_parser *const parser,
+        krabs_property_name *const property_name,
+        krabs_string_type string_type
+    );
+
+    FLATKRABSETW_API void krabs_destroy_user_provider(
+        krabs_user_provider *provider
+    );
+
+    FLATKRABSETW_API void krabs_destroy_user_trace(
         krabs_user_trace *trace
     );
 
-    FLATKRABSETW_API void krabs_destroy_user_provider(krabs_user_provider *provider);
+    FLATKRABSETW_API void krabs_destroy_event_filter(
+        krabs_filter *filter
+    );
 
-    FLATKRABSETW_API void krabs_destroy_user_trace(krabs_user_trace *trace);
+    FLATKRABSETW_API void krabs_destroy_event_schema(
+        krabs_event_schema *schema
+    );
 
-    FLATKRABSETW_API void krabs_destroy_event_filter(krabs_filter *filter);
+    FLATKRABSETW_API void krabs_destroy_event_parser(
+        krabs_event_parser *parser
+    );
+
+    FLATKRABSETW_API void krabs_destroy_property_name(
+        krabs_property_name *property_name
+    );
 
 #ifdef __cplusplus
 }

--- a/flatkrabsetw/flatkrabsetw.vcxproj
+++ b/flatkrabsetw/flatkrabsetw.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -14,19 +14,19 @@
     <ProjectGuid>{CE77C730-A9F4-4503-982F-6F9B004DFC06}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>flatkrabsetw</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -52,10 +52,11 @@
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;FLATKRABSETW_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -64,7 +65,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
@@ -72,6 +73,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;FLATKRABSETW_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -102,14 +104,14 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\boost.1.61.0.0\build\native\boost.targets" Condition="Exists('..\packages\boost.1.61.0.0\build\native\boost.targets')" />
     <Import Project="..\packages\krabsetw.1.0.0\build\native\krabsetw.targets" Condition="Exists('..\packages\krabsetw.1.0.0\build\native\krabsetw.targets')" />
+    <Import Project="..\packages\boost.1.68.0.0\build\boost.targets" Condition="Exists('..\packages\boost.1.68.0.0\build\boost.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\boost.1.61.0.0\build\native\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.61.0.0\build\native\boost.targets'))" />
     <Error Condition="!Exists('..\packages\krabsetw.1.0.0\build\native\krabsetw.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\krabsetw.1.0.0\build\native\krabsetw.targets'))" />
+    <Error Condition="!Exists('..\packages\boost.1.68.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.68.0.0\build\boost.targets'))" />
   </Target>
 </Project>

--- a/flatkrabsetw/flatkrabsetw.vcxproj.filters
+++ b/flatkrabsetw/flatkrabsetw.vcxproj.filters
@@ -35,9 +35,6 @@
     <ClCompile Include="dllmain.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\krabs.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/flatkrabsetw/flatkrabsetw.vcxproj.user
+++ b/flatkrabsetw/flatkrabsetw.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/flatkrabsetw/packages.config
+++ b/flatkrabsetw/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.61.0.0" targetFramework="native" />
+  <package id="boost" version="1.68.0.0" targetFramework="native" />
   <package id="krabsetw" version="1.0.0" targetFramework="native" />
+  <package id="Microsoft.O365.Security.Krabsetw" version="2.0.1" targetFramework="native" />
 </packages>

--- a/flatkrabsetw/stdafx.h
+++ b/flatkrabsetw/stdafx.h
@@ -6,7 +6,7 @@
 
 // Exclude rarely-used stuff from Windows headers
 #define WIN32_LEAN_AND_MEAN
+
 // Windows Header Files:
 #include <windows.h>
 #include <Evntcons.h>
-#include <stdbool.h>

--- a/flatkrabsetw/stdafx.h
+++ b/flatkrabsetw/stdafx.h
@@ -10,3 +10,5 @@
 // Windows Header Files:
 #include <windows.h>
 #include <Evntcons.h>
+#include <stdbool.h>
+#include <stdint.h>

--- a/flatkrabsetw/stdafx.h
+++ b/flatkrabsetw/stdafx.h
@@ -4,7 +4,8 @@
 
 #include "targetver.h"
 
-#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+// Exclude rarely-used stuff from Windows headers
+#define WIN32_LEAN_AND_MEAN
 // Windows Header Files:
 #include <windows.h>
 #include <Evntcons.h>

--- a/flatkrabsetw/targetver.h
+++ b/flatkrabsetw/targetver.h
@@ -5,7 +5,9 @@
 // If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
 // set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
 
+#define WINVER 0x0601
+#define _WIN32_WINNT 0x0601
+
 #include <WinSDKVer.h>
-#define _WIN32_WINNT _WIN32_WINNT_WIN7
 #include <SDKDDKVer.h>
 

--- a/flatkrabsetw/targetver.h
+++ b/flatkrabsetw/targetver.h
@@ -5,4 +5,7 @@
 // If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
 // set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
 
+#include <WinSDKVer.h>
+#define _WIN32_WINNT _WIN32_WINNT_WIN7
 #include <SDKDDKVer.h>
+

--- a/test_exe/main.cpp
+++ b/test_exe/main.cpp
@@ -4,9 +4,49 @@
 
 void handle_event(const EVENT_RECORD &rec)
 {
-    printf("event processed - eid: %d, pid: %d",
+    printf("event processed - eid: %d, pid: %d, context:\n",
         rec.EventHeader.EventDescriptor.Id,
         rec.EventHeader.ProcessId);
+
+    krabs_status_ctx status;
+    auto prop_name = krabs_create_property_name(&status, L"ContextInfo");
+
+    if (status.status != krabs_success) {
+        printf("error: %s\n", status.msg);
+        return;
+    }
+
+    auto schema = krabs_get_event_schema(&status, rec);
+    if (status.status != krabs_success) {
+        printf("error: %s\n", status.msg);
+        return;
+    }
+
+    auto parser = krabs_get_event_parser(&status, schema);
+    if (status.status != krabs_success) {
+        printf("error: %s\n", status.msg);
+        return;
+    }
+
+    auto context = krabs_get_string_property_from_parser(
+        &status,
+        parser,
+        prop_name,
+        krabs_string_type::std_wstring);
+    if (status.status != krabs_success) {
+        printf("error: %s\n", status.msg);
+        return;
+    }
+
+    wprintf(L"%ls\n", context);
+
+    if (context) {
+        delete context;
+    }
+    krabs_destroy_event_parser(parser);
+    krabs_destroy_event_schema(schema);
+    krabs_destroy_property_name(prop_name);
+
     printf("\n");
 }
 

--- a/test_exe/main.cpp
+++ b/test_exe/main.cpp
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <flatkrabsetw.h>
 
-void handle_event(const EVENT_RECORD & rec)
+void handle_event(const EVENT_RECORD &rec)
 {
     printf("event processed - eid: %d, pid: %d",
         rec.EventHeader.EventDescriptor.Id,
@@ -23,7 +23,6 @@ int main(void)
 
     auto provider = krabs_create_user_provider(
         &status,
-        trace,
         L"Microsoft-Windows-PowerShell",
         0xf0010000000003ff,
         0);
@@ -34,10 +33,24 @@ int main(void)
         return 1;
     }
 
-    krabs_add_event_callback_to_provider(&status, provider, handle_event);
+    USHORT event_id = 7937;
+    auto filter = krabs_create_filter_for_event_ids(&status, &event_id, 1);
+    if (status.status != krabs_success) {
+        printf("error: %s\n", status.msg);
+        return 1;
+    }
+
+    krabs_add_callback_to_event_filter(&status, filter, handle_event);
 
     if (status.status != krabs_success)
     {
+        printf("error: %s\n", status.msg);
+        return 1;
+    }
+
+    krabs_add_event_filter_to_user_provider(&status, provider, filter);
+
+    if (status.status != krabs_success) {
         printf("error: %s\n", status.msg);
         return 1;
     }

--- a/test_exe/main.cpp
+++ b/test_exe/main.cpp
@@ -1,20 +1,15 @@
+#include <ws2tcpip.h>
 #include <Windows.h>
 #include <stdio.h>
 #include <flatkrabsetw.h>
 
+#pragma comment(lib, "Ws2_32.lib")
+
 void handle_event(const EVENT_RECORD *rec)
 {
-    printf("event processed - eid: %d, pid: %d, context:\n",
-        rec->EventHeader.EventDescriptor.Id,
-        rec->EventHeader.ProcessId);
+    auto eid = rec->EventHeader.EventDescriptor.Id;
 
     krabs_status_ctx status;
-    auto prop_name = krabs_create_property_name(&status, L"ContextInfo");
-
-    if (status.status != krabs_success) {
-        printf("error: %s\n", status.msg);
-        return;
-    }
 
     auto schema = krabs_get_event_schema(&status, rec);
     if (status.status != krabs_success) {
@@ -28,24 +23,178 @@ void handle_event(const EVENT_RECORD *rec)
         return;
     }
 
-    auto context = krabs_get_string_property_from_parser(
-        &status,
-        parser,
-        prop_name,
-        krabs_string_type::std_wstring);
-    if (status.status != krabs_success) {
-        printf("error: %s\n", status.msg);
+    // Get the size.
+    uint32_t pid = 0;
+    {
+        auto prop_name = krabs_create_property_name(&status, L"PID");
+        if (status.status != krabs_success) {
+            printf("error: %s\n", status.msg);
+            return;
+        }
+
+        pid = krabs_get_u32_property_from_parser(
+            &status,
+            parser,
+            prop_name);
+        if (status.status != krabs_success) {
+            printf("error: %s\n", status.msg);
+            return;
+        }
+
+        krabs_destroy_property_name(prop_name);
+    }
+
+    // Get the size.
+    uint32_t size = 0;
+    {
+        auto prop_name = krabs_create_property_name(&status, L"size");
+        if (status.status != krabs_success) {
+            printf("error: %s\n", status.msg);
+            return;
+        }
+
+        size = krabs_get_u32_property_from_parser(
+            &status,
+            parser,
+            prop_name);
+        if (status.status != krabs_success) {
+            printf("error: %s\n", status.msg);
+            return;
+        }
+
+        krabs_destroy_property_name(prop_name);
+    }
+
+    // Get the Dport.
+    uint16_t dport = 0;
+    {
+        auto prop_name = krabs_create_property_name(&status, L"dport");
+        if (status.status != krabs_success) {
+            printf("error: %s\n", status.msg);
+            return;
+        }
+
+        dport = krabs_get_u16_property_from_parser(
+            &status,
+            parser,
+            prop_name);
+        if (status.status != krabs_success) {
+            printf("error: %s\n", status.msg);
+            return;
+        }
+
+        krabs_destroy_property_name(prop_name);
+    }
+
+    // Get the Dport.
+    uint16_t sport = 0;
+    {
+        auto prop_name = krabs_create_property_name(&status, L"sport");
+        if (status.status != krabs_success) {
+            printf("error: %s\n", status.msg);
+            return;
+        }
+
+        sport = krabs_get_u16_property_from_parser(
+            &status,
+            parser,
+            prop_name);
+        if (status.status != krabs_success) {
+            printf("error: %s\n", status.msg);
+            return;
+        }
+
+        krabs_destroy_property_name(prop_name);
+    }
+
+    // Get the Daddr.
+    krabs_ip_address *daddr = nullptr;
+    {
+        auto prop_name = krabs_create_property_name(&status, L"daddr");
+        if (status.status != krabs_success) {
+            printf("error: %s\n", status.msg);
+            return;
+        }
+
+        daddr = krabs_get_ip_addr_property_from_parser(
+            &status,
+            parser,
+            prop_name);
+        if (status.status != krabs_success) {
+            printf("error: %s\n", status.msg);
+            return;
+        }
+
+        krabs_destroy_property_name(prop_name);
+    }
+
+    // Get the Saddr.
+    krabs_ip_address *saddr = nullptr;
+    {
+        auto prop_name = krabs_create_property_name(&status, L"saddr");
+        if (status.status != krabs_success) {
+            printf("error: %s\n", status.msg);
+            return;
+        }
+
+        saddr = krabs_get_ip_addr_property_from_parser(
+            &status,
+            parser,
+            prop_name);
+        if (status.status != krabs_success) {
+            printf("error: %s\n", status.msg);
+            return;
+        }
+
+        krabs_destroy_property_name(prop_name);
+    }
+
+    switch (eid) {
+    case 10:
+        printf("PID: %d - TCPv4 (%d): ", pid, eid);
+        break;
+    case 26:
+        printf("PID: %d - TCPv6 (%d): ", pid, eid);
+        break;
+    case 42:
+        printf("PID: %d - UDPv4 (%d): ", pid, eid);
+        break;
+    case 58:
+        printf("PID: %d - UDPv6 (%d): ", pid, eid);
+        break;
+    default:
         return;
     }
 
-    wprintf(L"%ls\n", context);
+    char saddr_str[48] = { 0 };
+    if (saddr->is_ipv6) {
+        inet_ntop(AF_INET6, &saddr->v6, &saddr_str[0], ARRAYSIZE(saddr_str));
+    } else {
+        inet_ntop(AF_INET, &saddr->v4, &saddr_str[0], ARRAYSIZE(saddr_str));
+    }
 
-    if (context) {
-        delete context;
+    char daddr_str[48] = { 0 };
+    if (daddr->is_ipv6) {
+        inet_ntop(AF_INET6, &daddr->v6, &daddr_str[0], ARRAYSIZE(saddr_str));
+    } else {
+        inet_ntop(AF_INET, &daddr->v4, &daddr_str[0], ARRAYSIZE(saddr_str));
+    }
+
+    printf("%d bytes transmitted from %s:%d to %s:%d",
+        size,
+        saddr_str,
+        sport,
+        daddr_str,
+        dport);
+
+    if (daddr) {
+        delete daddr;
+    }
+    if (saddr) {
+        delete saddr;
     }
     krabs_destroy_event_parser(parser);
     krabs_destroy_event_schema(schema);
-    krabs_destroy_property_name(prop_name);
 
     printf("\n");
 }
@@ -63,8 +212,8 @@ int main(void)
 
     auto provider = krabs_create_user_provider(
         &status,
-        L"Microsoft-Windows-PowerShell",
-        0xf0010000000003ff,
+        L"Microsoft-Windows-Kernel-Network",
+        0x8000000000000000,
         0);
 
     if (status.status != krabs_success)
@@ -73,8 +222,13 @@ int main(void)
         return 1;
     }
 
-    USHORT event_id = 7937;
-    auto filter = krabs_create_filter_for_event_ids(&status, &event_id, 1);
+    USHORT event_ids[] = {
+        10,
+        26,
+        42,
+        58
+    };
+    auto filter = krabs_create_filter_for_event_ids(&status, &event_ids[0], ARRAYSIZE(event_ids));
     if (status.status != krabs_success) {
         printf("error: %s\n", status.msg);
         return 1;

--- a/test_exe/main.cpp
+++ b/test_exe/main.cpp
@@ -2,11 +2,11 @@
 #include <stdio.h>
 #include <flatkrabsetw.h>
 
-void handle_event(const EVENT_RECORD &rec)
+void handle_event(const EVENT_RECORD *rec)
 {
     printf("event processed - eid: %d, pid: %d, context:\n",
-        rec.EventHeader.EventDescriptor.Id,
-        rec.EventHeader.ProcessId);
+        rec->EventHeader.EventDescriptor.Id,
+        rec->EventHeader.ProcessId);
 
     krabs_status_ctx status;
     auto prop_name = krabs_create_property_name(&status, L"ContextInfo");

--- a/test_exe/test_exe.vcxproj
+++ b/test_exe/test_exe.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -22,32 +22,32 @@
     <ProjectGuid>{B44E6308-3F11-4955-AF7D-BFE104C730B0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>test_exe</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/test_exe/test_exe.vcxproj.user
+++ b/test_exe/test_exe.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>


### PR DESCRIPTION
This change adds a number of features to modernize the flatkrabsetw project from its previously dead state:

- upgrade to VS2017 toolchain
- explicitly target Windows 7 and above
- fix API surface to be truly C ABI, removing any C++ artifacts
- add `krabs::schema`, `krabs::parser`, and property value getters
- update the example test_exe to show pulling data from the `Microsoft-Windows-Kernel-Network` provider